### PR TITLE
Add launch configuration for Chrome in launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "Launch Chrome against localhost",
+            "url": "http://localhost:8080",
+            "webRoot": "${workspaceFolder}"
+        }
+    ]
+}


### PR DESCRIPTION
Adds launch configuration for Chrome in launch.json

Introduces a new launch configuration to facilitate debugging with Chrome against a local server running at http://localhost:8080.

This configuration enhances the development workflow by allowing quick access to the application in a browser environment.